### PR TITLE
bugfix: on mac one can use core-utils/gdate instead of failing with date

### DIFF
--- a/lib/main.sh
+++ b/lib/main.sh
@@ -10,20 +10,27 @@ function main() {
 	init_dir './data'
 	test_deps
 
-	declare -A -x command_table=(
-		['pull']="pull_chart_from_release"
-		['upgrade']="upgrade_release"
-		['ttl']="release_ttl"
-	)
-
-	local commands="${!command_table[@]}"
+	local commands="pull upgrade ttl"
 	local msg="usage: helm release [ $commands ]"
 	if [[ $# < 1 ]]; then exit_with_help "$msg"; fi
 
 	local command=${1}; shift
-	local fn_name=${command_table[$command]}
+	local fn_name=""
 
-	if [[ $fn_name == '' ]]; then exit_with_help "$msg"; fi
+	case "$command" in
+		"pull")
+			fn_name="pull_chart_from_release"
+			;;
+		"upgrade")
+			fn_name="upgrade_release"
+			;;
+		"ttl")
+			fn_name="release_ttl"
+			;;
+		*)
+			exit_with_help "$msg"
+			;;
+	esac
 	if $fn_name "$@"; then
 		rm -Rf $(dirname -- "$0")/data;
 		return 0;

--- a/lib/utility.sh
+++ b/lib/utility.sh
@@ -14,6 +14,18 @@ function test_deps() {
 		echo "jq could not be found - please install command `jq` (https://stedolan.github.io/jq/download/)"
 		exit
 	fi
+
+
+	if ! date --utc +%s > /dev/null 2>&1; then
+		if ! command -v gdate &> /dev/null; then
+			echo "gdate could not be found - please install command `gdate` (https://www.gnu.org/software/coreutils/)"
+			echo "If you are on macOS, you can install it using Homebrew: `brew install coreutils`"
+			exit
+		else
+			alias date='gdate'
+		fi
+	fi
+
 }
 
 function str_split() {


### PR DESCRIPTION
added behaviour:
- in case `date` does not work as *expected*, (eg on mac: https://stackoverflow.com/questions/9804966/date-command-does-not-follow-linux-specifications-mac-os-x-lion) we fall back to `gdate`. 
- in case the user has no gdate installed, we let him know.