### PR TITLE
chore: fix cronbjob ttl self cleaner. bitnami image nog longer exists/maintained

### DIFF
--- a/lib/api/ttl.sh
+++ b/lib/api/ttl.sh
@@ -75,7 +75,7 @@ function create_ttl() {
                       args: [ 'uninstall', '$RELEASE' ]
                   containers:
                     - name: release-ttl-cleaner
-                      image: bitnami/kubectl:$KUBECTL_VERSION
+                      image: alpine/kubectl:$KUBECTL_VERSION
                       imagePullPolicy: IfNotPresent
                       args: [ 'delete', 'cronjob', '$cronjob_name' ]
                   restartPolicy: OnFailure


### PR DESCRIPTION
after deleting the helm release it cannot cleanup itself due to the missing `bitnami/kubectl` image