### PR TITLE
chore: upgrade helm and kubectl versions

### DIFF
--- a/lib/api/ttl.sh
+++ b/lib/api/ttl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-HELM_VERSION="3.17.0"
-KUBECTL_VERSION="1.32.1"
+HELM_VERSION="3.20.0"
+KUBECTL_VERSION="1.35.1"
 
 help_text="
 Sets release TTL. Under the hood creates Kubernetes CronJob that will delete specific release in concrete time.


### PR DESCRIPTION
The old kubectl version no longer exists.